### PR TITLE
Fix: Admin Revoke (Delete messages from others)

### DIFF
--- a/docs/wiki/guias-api/api-messages.md
+++ b/docs/wiki/guias-api/api-messages.md
@@ -894,8 +894,10 @@ Deleta uma mensagem para todos (revoke).
 **Body**:
 ```json
 {
-  "chat": "5511999999999@s.whatsapp.net",
-  "messageId": "3EB0C5A277F7F9B6C599"
+  "chat": "120363XXXXXXXXXX@g.us",
+  "messageId": "3EB0C5A277F7F9B6C599",
+  "fromMe": false,
+  "participant": "5511888888888@s.whatsapp.net"
 }
 ```
 
@@ -905,8 +907,13 @@ Deleta uma mensagem para todos (revoke).
 |-------|------|-------------|-----------|
 | `chat` | string | ✅ Sim | JID do chat |
 | `messageId` | string | ✅ Sim | ID da mensagem a deletar |
+| `fromMe` | bool | ❌ Não | Se a mensagem foi enviada por você (padrão: true) |
+| `participant` | string | ❌ Não | JID do autor (obrigatório se fromMe=false em grupos) |
 
-**Nota**: Só é possível deletar mensagens enviadas por você. O WhatsApp tem limite de tempo para deletar mensagens (geralmente até 1 hora).
+**Nota**: 
+- Para deletar suas próprias mensagens, use `fromMe: true` (ou omita).
+- Para deletar mensagens de **outros usuários** (Admin Revoke), você deve ser **administrador** do grupo e passar `fromMe: false` e o `participant` (JID do autor).
+- O WhatsApp tem um limite de tempo para deletar suas próprias mensagens (geralmente ~2 dias), mas admins podem deletar mensagens de outros a qualquer momento.
 
 **Resposta de Sucesso (200)**:
 ```json
@@ -921,12 +928,24 @@ Deleta uma mensagem para todos (revoke).
 
 **Exemplo cURL**:
 ```bash
+# Deletar sua própria mensagem
 curl -X POST http://localhost:4000/message/delete \
   -H "Content-Type: application/json" \
   -H "apikey: SUA-CHAVE-API" \
   -d '{
     "chat": "5511999999999@s.whatsapp.net",
     "messageId": "3EB0C5A277F7F9B6C599"
+  }'
+
+# Deletar mensagem de outro (Admin Revoke)
+curl -X POST http://localhost:4000/message/delete \
+  -H "Content-Type: application/json" \
+  -H "apikey: SUA-CHAVE-API" \
+  -d '{
+    "chat": "120363XXXXXXXXXX@g.us",
+    "messageId": "3EB0C5A277F7F9B6C599",
+    "fromMe": false,
+    "participant": "5511888888888@s.whatsapp.net"
   }'
 ```
 

--- a/pkg/message/service/message_service.go
+++ b/pkg/message/service/message_service.go
@@ -68,8 +68,10 @@ type MessageStatusStruct struct {
 }
 
 type MessageStruct struct {
-	Chat      string `json:"chat"`
-	MessageID string `json:"messageId"`
+	Chat        string `json:"chat"`
+	MessageID   string `json:"messageId"`
+	FromMe      bool   `json:"fromMe"`
+	Participant string `json:"participant,omitempty"`
 }
 
 type EditMessageStruct struct {
@@ -376,12 +378,27 @@ func (m *messageService) DeleteMessageEveryone(data *MessageStruct, instance *in
 		return "", "", errors.New("invalid phone number")
 	}
 
+	var senderJID types.JID
+	if data.FromMe {
+		senderJID = types.EmptyJID
+	} else {
+		if data.Participant == "" {
+			return "", "", errors.New("participant is required to delete a message from another user")
+		}
+		parsedJID, ok := utils.ParseJID(data.Participant)
+		if !ok {
+			m.loggerWrapper.GetLogger(instance.Id).LogError("[%s] Error parsing participant JID for non-FromMe message: %s", data.Participant)
+			return "", "", errors.New("invalid participant JID")
+		}
+		senderJID = parsedJID
+	}
+
 	m.loggerWrapper.GetLogger(instance.Id).LogInfo("Revoking message %s from %s", data.MessageID, recipient)
 
 	resp, err := client.SendMessage(
 		context.Background(),
 		recipient,
-		client.BuildRevoke(recipient, types.EmptyJID, data.MessageID))
+		client.BuildRevoke(recipient, senderJID, data.MessageID))
 	if err != nil {
 		m.loggerWrapper.GetLogger(instance.Id).LogError("[%s] error revoking message: %v", instance.Id, err)
 		return "", "", err

--- a/pkg/message/service/message_service.go
+++ b/pkg/message/service/message_service.go
@@ -70,7 +70,7 @@ type MessageStatusStruct struct {
 type MessageStruct struct {
 	Chat        string `json:"chat"`
 	MessageID   string `json:"messageId"`
-	FromMe      bool   `json:"fromMe"`
+	FromMe      *bool  `json:"fromMe"`
 	Participant string `json:"participant,omitempty"`
 }
 
@@ -379,7 +379,7 @@ func (m *messageService) DeleteMessageEveryone(data *MessageStruct, instance *in
 	}
 
 	var senderJID types.JID
-	if data.FromMe {
+	if data.FromMe == nil || *data.FromMe {
 		senderJID = types.EmptyJID
 	} else {
 		if data.Participant == "" {
@@ -387,7 +387,7 @@ func (m *messageService) DeleteMessageEveryone(data *MessageStruct, instance *in
 		}
 		parsedJID, ok := utils.ParseJID(data.Participant)
 		if !ok {
-			m.loggerWrapper.GetLogger(instance.Id).LogError("[%s] Error parsing participant JID for non-FromMe message: %s", data.Participant)
+			m.loggerWrapper.GetLogger(instance.Id).LogError("[%s] Error parsing participant JID for non-FromMe message: %s", instance.Id, data.Participant)
 			return "", "", errors.New("invalid participant JID")
 		}
 		senderJID = parsedJID


### PR DESCRIPTION
Fixes the limitation where group admins were unable to delete messages sent by other participants via the API. This enables the "admin revoke" functionality.

These changes have been in effect in my codebase since december (early acess) - throughly tested.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

### Testing
- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced

### Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [x] Any dependent changes have been merged and published

## Summary by Sourcery

Enable revoking messages sent by other participants in group chats via the message delete API.

Bug Fixes:
- Allow group admins to delete messages sent by other users by correctly passing the original sender JID when revoking messages.

Enhancements:
- Extend message delete payload to support specifying whether the message is from the caller and, when needed, the original participant JID.

Documentation:
- Update API message deletion docs with new fromMe and participant fields, clarify admin revoke behavior and time limits, and add examples for deleting own and others' messages.