### PR TITLE
Fix: Sticker Image Decoding and GIF Support

### DIFF
--- a/pkg/sendMessage/service/send_service.go
+++ b/pkg/sendMessage/service/send_service.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -1417,6 +1418,12 @@ func (s *sendService) sendPollWithRetry(data *PollStruct, instance *instance_mod
 	return nil, fmt.Errorf("failed to send poll after %d attempts", maxRetries)
 }
 
+const (
+	stickerMaxDownloadSize = 10 * 1024 * 1024 // 10MB
+	stickerDownloadTimeout = 30 * time.Second
+	stickerFFmpegTimeout  = 60 * time.Second
+)
+
 func convertVideoToWebP(inputData []byte, transparentColor string) ([]byte, error) {
 	tmpInput, err := os.CreateTemp("", "sticker-input-*.mp4")
 	if err != nil {
@@ -1445,7 +1452,10 @@ func convertVideoToWebP(inputData []byte, transparentColor string) ([]byte, erro
 		filters = fmt.Sprintf("colorkey=0x%s:0.1:0.0,%s", cleanHex, baseFilters)
 	}
 
-	cmd := exec.Command("ffmpeg",
+	ctx, cancel := context.WithTimeout(context.Background(), stickerFFmpegTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ffmpeg",
 		"-i", tmpInput.Name(),
 		"-vcodec", "libwebp",
 		"-filter:v", filters,
@@ -1474,15 +1484,28 @@ func convertVideoToWebP(inputData []byte, transparentColor string) ([]byte, erro
 }
 
 func convertToWebP(imageDataURL string, transparentColor string) ([]byte, error) {
-	resp, err := http.Get(imageDataURL)
+	client := &http.Client{
+		Timeout: stickerDownloadTimeout,
+	}
+
+	resp, err := client.Get(imageDataURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch from URL: %v", err)
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch from URL: status code %d", resp.StatusCode)
+	}
+
+	// Limitar o tamanho da leitura para evitar exaustão de recursos
+	data, err := io.ReadAll(io.LimitReader(resp.Body, stickerMaxDownloadSize))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	if int64(len(data)) >= stickerMaxDownloadSize {
+		return nil, fmt.Errorf("sticker size exceeds limit of %d bytes", stickerMaxDownloadSize)
 	}
 
 	mime := mimetype.Detect(data)

--- a/pkg/sendMessage/service/send_service.go
+++ b/pkg/sendMessage/service/send_service.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	_ "image/gif"
+	_ "image/jpeg"
 	"image/png"
 	"io"
 	"mime/multipart"
@@ -122,14 +124,15 @@ type PollStruct struct {
 }
 
 type StickerStruct struct {
-	Number       string       `json:"number"`
-	Sticker      string       `json:"sticker"`
-	Id           string       `json:"id"`
-	Delay        int32        `json:"delay"`
-	MentionedJID []string     `json:"mentionedJid"`
-	MentionAll   bool         `json:"mentionAll"`
-	FormatJid    *bool        `json:"formatJid,omitempty"`
-	Quoted       QuotedStruct `json:"quoted"`
+	Number           string       `json:"number"`
+	Sticker          string       `json:"sticker"`
+	Id               string       `json:"id"`
+	Delay            int32        `json:"delay"`
+	MentionedJID     []string     `json:"mentionedJid"`
+	MentionAll       bool         `json:"mentionAll"`
+	FormatJid        *bool        `json:"formatJid,omitempty"`
+	TransparentColor string       `json:"transparentColor,omitempty"`
+	Quoted           QuotedStruct `json:"quoted"`
 }
 
 type LocationStruct struct {
@@ -1414,28 +1417,95 @@ func (s *sendService) sendPollWithRetry(data *PollStruct, instance *instance_mod
 	return nil, fmt.Errorf("failed to send poll after %d attempts", maxRetries)
 }
 
-func convertToWebP(imageData string) ([]byte, error) {
-	var img image.Image
-	var err error
-
-	resp, err := http.Get(imageData)
+func convertVideoToWebP(inputData []byte, transparentColor string) ([]byte, error) {
+	tmpInput, err := os.CreateTemp("", "sticker-input-*.mp4")
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch image from URL: %v", err)
+		return nil, fmt.Errorf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpInput.Name())
+
+	if _, err := tmpInput.Write(inputData); err != nil {
+		tmpInput.Close()
+		return nil, fmt.Errorf("failed to write to temp file: %v", err)
+	}
+
+	if err := tmpInput.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close temp file: %v", err)
+	}
+
+	tmpOutput := tmpInput.Name() + ".webp"
+	defer os.Remove(tmpOutput)
+
+	// Filtros base: scale, pad, fps e loop
+	baseFilters := "fps=15,scale=512:512:force_original_aspect_ratio=decrease,pad=512:512:(ow-iw)/2:(oh-ih)/2:color=0x00000000"
+
+	filters := baseFilters
+	if transparentColor != "" {
+		cleanHex := strings.ReplaceAll(transparentColor, "#", "")
+		filters = fmt.Sprintf("colorkey=0x%s:0.1:0.0,%s", cleanHex, baseFilters)
+	}
+
+	cmd := exec.Command("ffmpeg",
+		"-i", tmpInput.Name(),
+		"-vcodec", "libwebp",
+		"-filter:v", filters,
+		"-lossless", "0",
+		"-compression_level", "4",
+		"-q:v", "50",
+		"-loop", "0",
+		"-an",
+		"-f", "webp",
+		tmpOutput,
+	)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("ffmpeg failed: %v, output: %s", err, stderr.String())
+	}
+
+	webpData, err := os.ReadFile(tmpOutput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read generated webp: %v", err)
+	}
+
+	return webpData, nil
+}
+
+func convertToWebP(imageDataURL string, transparentColor string) ([]byte, error) {
+	resp, err := http.Get(imageDataURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch from URL: %v", err)
 	}
 	defer resp.Body.Close()
 
-	img, _, err = image.Decode(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode image: %v", err)
+		return nil, fmt.Errorf("failed to read response body: %v", err)
 	}
 
-	var webpBuffer bytes.Buffer
-	err = webp.Encode(&webpBuffer, img, &webp.Options{Lossless: false, Quality: 80})
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode image to WebP: %v", err)
+	mime := mimetype.Detect(data)
+
+	if mime.Is("image/webp") {
+		return data, nil
+	} else if mime.Is("video/mp4") || mime.Is("image/gif") {
+		return convertVideoToWebP(data, transparentColor)
+	} else if mime.Is("image/jpeg") || mime.Is("image/png") || mime.Is("image/jpg") {
+		img, _, err := image.Decode(bytes.NewReader(data))
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode image: %v", err)
+		}
+
+		var webpBuffer bytes.Buffer
+		err = webp.Encode(&webpBuffer, img, &webp.Options{Lossless: false, Quality: 80})
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode image to WebP: %v", err)
+		}
+		return webpBuffer.Bytes(), nil
 	}
 
-	return webpBuffer.Bytes(), nil
+	return nil, fmt.Errorf("unsupported format: %s", mime.String())
 }
 
 func (s *sendService) SendSticker(data *StickerStruct, instance *instance_model.Instance) (*MessageSendStruct, error) {
@@ -1448,7 +1518,7 @@ func (s *sendService) SendSticker(data *StickerStruct, instance *instance_model.
 	var filedata []byte
 
 	if strings.HasPrefix(data.Sticker, "http") {
-		webpData, err := convertToWebP(data.Sticker)
+		webpData, err := convertToWebP(data.Sticker, data.TransparentColor)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert image to WebP: %v", err)
 		}


### PR DESCRIPTION
Fixes the "failed to decode image: image: unknown format" error by explicitly registering `image/jpeg` and `image/gif` decoders in the Go environment. Additionally, it updates the `convertToWebP` logic to support GIF images by routing them through the FFmpeg conversion pipeline, enabling both static and animated GIFs to be sent as stickers.

These changes have been in effect in my codebase for 3 days now, no other conversion errors popped up while testing.

### Related Issue
Closes #5

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

### Testing
- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced

### Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [x] Any dependent changes have been merged and published

## Summary by Sourcery

Handle additional image formats for sticker conversion and support GIF/video-based stickers via FFmpeg.

Bug Fixes:
- Register JPEG and GIF decoders to prevent image decoding failures when generating stickers.
- Improve sticker conversion to correctly process JPEG, PNG, GIF, and MP4 inputs into WebP, returning an error for unsupported formats.

Enhancements:
- Add support for animated and GIF-based stickers by routing GIF and MP4 content through an FFmpeg-based WebP conversion pipeline.
- Extend sticker payloads with an optional transparentColor field to enable background color keying during video-to-WebP conversion.