### PR TITLE
Improvement: Add cache to WhatsApp Web version with concurrency control.

### DIFF
--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/image/webp"
@@ -2293,7 +2294,21 @@ func (w *whatsmeowService) SendToGlobalQueues(eventType string, payload []byte, 
 	}
 }
 
+var (
+	cachedWebVersion     *clientVersion
+	cachedWebVersionAt   time.Time
+	cachedWebVersionMu   sync.Mutex
+	webVersionCacheTTL   = 1 * time.Hour
+)
+
 func fetchWhatsAppWebVersion() (*clientVersion, error) {
+	cachedWebVersionMu.Lock()
+	defer cachedWebVersionMu.Unlock()
+
+	if cachedWebVersion != nil && time.Since(cachedWebVersionAt) < webVersionCacheTTL {
+		return cachedWebVersion, nil
+	}
+
 	resp, err := http.Get("https://web.whatsapp.com/sw.js")
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch WhatsApp Web version: %v", err)
@@ -2327,11 +2342,13 @@ func fetchWhatsAppWebVersion() (*clientVersion, error) {
 
 			// Log qual padrão funcionou
 			if clientRevision > 0 {
-				return &clientVersion{
+				cachedWebVersion = &clientVersion{
 					Major: 2,
 					Minor: 3000,
 					Patch: clientRevision,
-				}, nil
+				}
+				cachedWebVersionAt = time.Now()
+				return cachedWebVersion, nil
 			}
 		}
 	}


### PR DESCRIPTION
## Description
Evolution GO was making a request to https://web.whatsapp.com/sw.js for each instance that was started. Therefore, if the API had 1000 connected instances, that would be 1000 requests fetching the current version of WhatsApp Web using fetchWhatsAppWebVersion(). Now, we cache the first response and set a TTL of 1 hour. In other words, for 1 hour the same version of WhatsApp Web will be used for any connected instance.

This prevents multiple unnecessary requests from being made.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [X] Performance improvement

## Testing
- [X] Manual testing completed
- [X] Functionality verified in development environment
- [X] No breaking changes introduced

## Checklist
- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have tested my changes thoroughly
- [X] Any dependent changes have been merged and published

## Additional Notes

## Summary by Sourcery

Cache WhatsApp Web version lookups with a time-limited, concurrency-safe in-memory cache to reduce repeated external requests.

New Features:
- Introduce an in-memory cache for the WhatsApp Web client version with a one-hour TTL shared across instances.

Enhancements:
- Add mutex-based concurrency control around WhatsApp Web version retrieval to prevent redundant simultaneous fetches and improve performance.