### PR TITLE
fix(user): retry group avatar fetch with IsCommunity on failure

### DIFF
--- a/pkg/user/service/user_service.go
+++ b/pkg/user/service/user_service.go
@@ -349,6 +349,15 @@ func (u *userService) GetAvatar(data *GetAvatarStruct, instance *instance_model.
 	pic, err = client.GetProfilePictureInfo(ctx, jid, &whatsmeow.GetProfilePictureParams{
 		Preview: data.Preview,
 	})
+	// Group/community JIDs may be rejected on the regular profile-picture query
+	// (401 not-authorized) and require the community variant instead.
+	if err != nil && jid.Server == types.GroupServer {
+		u.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] GetProfilePictureInfo failed for group JID (%v), retrying with IsCommunity", instance.Id, err)
+		pic, err = client.GetProfilePictureInfo(ctx, jid, &whatsmeow.GetProfilePictureParams{
+			Preview:     data.Preview,
+			IsCommunity: true,
+		})
+	}
 	if err != nil {
 		u.loggerWrapper.GetLogger(instance.Id).LogError("[%s] GetProfilePictureInfo failed: %v", instance.Id, err)
 		return nil, err

--- a/pkg/user/service/user_service.go
+++ b/pkg/user/service/user_service.go
@@ -336,7 +336,8 @@ func (u *userService) GetAvatar(data *GetAvatarStruct, instance *instance_model.
 		return nil, errors.New("invalid phone number")
 	}
 
-	u.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Requesting avatar for JID: %s, Preview: %v", instance.Id, jid, data.Preview)
+	log := u.loggerWrapper.GetLogger(instance.Id)
+	log.LogInfo("[%s] Requesting avatar for JID: %s, Preview: %v", instance.Id, jid, data.Preview)
 
 	var pic *types.ProfilePictureInfo
 
@@ -345,21 +346,22 @@ func (u *userService) GetAvatar(data *GetAvatarStruct, instance *instance_model.
 	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Second)
 	defer cancel()
 
-	u.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Starting GetProfilePictureInfo request...", instance.Id)
+	log.LogInfo("[%s] Starting GetProfilePictureInfo request...", instance.Id)
 	pic, err = client.GetProfilePictureInfo(ctx, jid, &whatsmeow.GetProfilePictureParams{
 		Preview: data.Preview,
 	})
-	// Group/community JIDs may be rejected on the regular profile-picture query
-	// (401 not-authorized) and require the community variant instead.
-	if err != nil && jid.Server == types.GroupServer {
-		u.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] GetProfilePictureInfo failed for group JID (%v), retrying with IsCommunity", instance.Id, err)
+	// Group/community JIDs are rejected with not-authorized on the regular
+	// profile-picture query and require the community variant instead. Retry
+	// only on that specific error so unrelated failures surface unchanged.
+	if jid.Server == types.GroupServer && errors.Is(err, whatsmeow.ErrProfilePictureUnauthorized) {
+		log.LogDebug("[%s] Group JID not authorized on regular query, retrying with IsCommunity", instance.Id)
 		pic, err = client.GetProfilePictureInfo(ctx, jid, &whatsmeow.GetProfilePictureParams{
 			Preview:     data.Preview,
 			IsCommunity: true,
 		})
 	}
 	if err != nil {
-		u.loggerWrapper.GetLogger(instance.Id).LogError("[%s] GetProfilePictureInfo failed: %v", instance.Id, err)
+		log.LogError("[%s] GetProfilePictureInfo failed: %v", instance.Id, err)
 		return nil, err
 	}
 
@@ -367,7 +369,7 @@ func (u *userService) GetAvatar(data *GetAvatarStruct, instance *instance_model.
 		return nil, errors.New("no profile picture found")
 	}
 
-	u.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Got avatar %s", instance.Id, pic.URL)
+	log.LogInfo("[%s] Got avatar %s", instance.Id, pic.URL)
 
 	return pic, nil
 }


### PR DESCRIPTION
## Problem

`POST /user/avatar` always returns **500** when the `number` is a group JID (`…@g.us`).

`GetAvatar` calls whatsmeow's `GetProfilePictureInfo` with only `Preview` set. For group/community JIDs the regular `w:profile:picture` query is rejected by WhatsApp with `401 not-authorized`, which surfaces as a 500 to the API consumer. whatsmeow itself documents this in `GetProfilePictureParams`: *"To get a community photo, you should pass IsCommunity: true, as otherwise you may get a 401 error."*

Reproduced live:

```
POST /user/avatar {"number":"120363044414041265@g.us","preview":false}
→ 401 {"error":"not authorized"}
```

## Fix

When the first `GetProfilePictureInfo` attempt fails **and** the JID server is `g.us`, retry once with `IsCommunity: true`. Regular user JIDs are untouched — same single call as before.

```go
if err != nil && jid.Server == types.GroupServer {
    pic, err = client.GetProfilePictureInfo(ctx, jid, &whatsmeow.GetProfilePictureParams{
        Preview:     data.Preview,
        IsCommunity: true,
    })
}
```

## Testing

- `go build ./pkg/...` clean.
- Verified against a live instance: group JIDs that previously returned 500/401 now return the picture payload (`url`, `id`, `type`, `direct_path`); user JIDs unchanged.

## Summary by Sourcery

Bug Fixes:
- Fix group JID avatar requests that previously failed with authorization errors by retrying the lookup using community avatar parameters.